### PR TITLE
fix: race condition in ginkgo tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint: lint/check ## run golangci-lint
 	fi
 
 test: lint ## Run tests
-	go test ./... -coverprofile cover.out
+	go test -v -race ./... -coverprofile cover.out
 
 build: generate ## Build manager binary
 	CGO_ENABLED=0 go build -a -ldflags '$(LDFLAGS)' -o bin/manager ./cmd/controller/main.go

--- a/pkg/controller/externalsecret/controller_test.go
+++ b/pkg/controller/externalsecret/controller_test.go
@@ -89,24 +89,30 @@ var _ = Describe("ExternalSecrets Controller", func() {
 
 			By("Creating the ExternalSecret successfully")
 			Expect(k8sClient.Create(context.Background(), toCreate)).Should(Succeed())
-			time.Sleep(time.Second * 5)
+			defer func() {
+				By("Deleting the ExternalSecret successfully")
+				Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
+			}()
 
 			fetched := &smv1alpha1.ExternalSecret{}
 			Eventually(func() bool {
+				By("Fetching the ExternalSecret successfully")
 				k8sClient.Get(context.Background(), key, fetched)
+				By("Checking the Status Condition")
 				fetchedCond := fetched.Status.GetCondition(smmeta.TypeReady)
 				return fetchedCond.Matches(smmeta.Unavailable()) &&
 					matches(fetchedCond.Message, errStoreNotFound)
 			}, timeout, interval).Should(BeTrue())
-
-			By("Deleting the ExternalSecret successfully")
-			Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
 		})
 
 		It("An ExternalSecret referencing a SecretStore with invalid credentials should be NotReady", func() {
 			store := sampleStore.DeepCopy()
+			By("Creating the SecretStore successfully")
 			Expect(k8sClient.Create(context.Background(), store)).Should(Succeed())
-
+			defer func() {
+				By("Deleting the SecretStore successfully")
+				Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
+			}()
 			spec := smv1alpha1.ExternalSecretSpec{
 				StoreRef: smv1alpha1.ObjectReference{
 					Name: store.Name,
@@ -137,31 +143,34 @@ var _ = Describe("ExternalSecrets Controller", func() {
 			}
 
 			storeFactory.WithNew(func(context.Context, client.Client, smv1alpha1.GenericStore, string) (*fakestore.Factory, error) {
-				return nil, fmt.Errorf("fail to setup store client")
+				return nil, fmt.Errorf("artificial test error")
 			})
 
 			By("Creating the ExternalSecret successfully")
 			Expect(k8sClient.Create(context.Background(), toCreate)).Should(Succeed())
-			time.Sleep(time.Second * 5)
-
+			defer func() {
+				By("Deleting the ExternalSecret successfully")
+				Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
+			}()
 			fetched := &smv1alpha1.ExternalSecret{}
 			Eventually(func() bool {
+				By("Fetching the ExternalSecret successfully")
 				k8sClient.Get(context.Background(), key, fetched)
+				By("Checking the status condition")
 				fetchedCond := fetched.Status.GetCondition(smmeta.TypeReady)
 				return fetchedCond.Matches(smmeta.Unavailable()) &&
 					matches(fetchedCond.Message, errStoreSetupFailed)
 			}, timeout, interval).Should(BeTrue())
-
-			By("Deleting the ExternalSecret successfully")
-			Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
-			By("Deleting the SecretStore successfully")
-			Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
 		})
 
 		It("An ExternalSecret with a valid SecretStore should generate a Secret", func() {
 			store := sampleStore.DeepCopy()
+			By("Creating the SecretStore successfully")
 			Expect(k8sClient.Create(context.Background(), store)).Should(Succeed())
-
+			defer func() {
+				By("Deleting the SecretStore successfully")
+				Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
+			}()
 			spec := smv1alpha1.ExternalSecretSpec{
 				StoreRef: smv1alpha1.ObjectReference{
 					Name: store.Name,
@@ -202,19 +211,24 @@ var _ = Describe("ExternalSecrets Controller", func() {
 
 			By("Creating the ExternalSecret successfully")
 			Expect(k8sClient.Create(context.Background(), toCreate)).Should(Succeed())
-			time.Sleep(time.Second * 5)
-
+			defer func() {
+				By("Deleting the ExternalSecret successfully")
+				Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
+			}()
 			fetched := &smv1alpha1.ExternalSecret{}
 			Eventually(func() bool {
+				By("Fetching the ExternalSecret successfully")
 				Expect(k8sClient.Get(context.Background(), key, fetched)).Should(Succeed())
+				By("Checking the status condition")
 				fetchedCond := fetched.Status.GetCondition(smmeta.TypeReady)
 				return fetchedCond.Matches(smmeta.Available())
 			}, timeout, interval).Should(BeTrue(), "The ExternalSecret should have a ready condition")
 
 			fetchedSecret := &corev1.Secret{}
 			Eventually(func() bool {
+				By("Fetching the Secret successfully")
 				Expect(k8sClient.Get(context.Background(), key, fetchedSecret)).Should(Succeed())
-				return true
+				return matches(string(fetchedSecret.Data["key"]), string(expectedData["key"]))
 			}, timeout, interval).Should(BeTrue(), "The generated secret should be created")
 
 			Expect(len(fetchedSecret.OwnerReferences)).Should(BeIdenticalTo(1),
@@ -223,21 +237,16 @@ var _ = Describe("ExternalSecrets Controller", func() {
 				"The owner kind should be ExternalSecret")
 			Expect(fetchedSecret.OwnerReferences[0].Name).Should(BeIdenticalTo(toCreate.Name),
 				"The owner name should be the name of the ExternalSecret")
-
-			Expect(fetchedSecret.Data).Should(Equal(expectedData), "Secret data should match test data")
-
-			By("Deleting the ExternalSecret successfully")
-			Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
-			By("Deleting the Secret successfully")
-			Expect(k8sClient.Delete(context.Background(), fetchedSecret)).Should(Succeed())
-			By("Deleting the SecretStore successfully")
-			Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
 		})
 
 		It("An ExternalSecret with dataFrom specified should generate secret", func() {
 			store := sampleStore.DeepCopy()
+			By("Creating the SecretStore successfully")
 			Expect(k8sClient.Create(context.Background(), store)).Should(Succeed())
-
+			defer func() {
+				By("Deleting the SecretStore successfully")
+				Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
+			}()
 			spec := smv1alpha1.ExternalSecretSpec{
 				StoreRef: smv1alpha1.ObjectReference{
 					Name: store.Name,
@@ -294,35 +303,41 @@ var _ = Describe("ExternalSecrets Controller", func() {
 
 			By("Creating the ExternalSecret successfully")
 			Expect(k8sClient.Create(context.Background(), toCreate)).Should(Succeed())
-			time.Sleep(time.Second * 5)
-
+			defer func() {
+				By("Deleting the ExternalSecret successfully")
+				Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
+			}()
 			fetched := &smv1alpha1.ExternalSecret{}
 			Eventually(func() bool {
+				By("Fetching the ExternalSecret successfully")
 				Expect(k8sClient.Get(context.Background(), key, fetched)).Should(Succeed())
+				By("Checking the Status Condition")
 				fetchedCond := fetched.Status.GetCondition(smmeta.TypeReady)
 				return fetchedCond.Matches(smmeta.Available())
 			}, timeout, interval).Should(BeTrue(), "The ExternalSecret should have a ready condition")
 
 			fetchedSecret := &corev1.Secret{}
 			Eventually(func() bool {
+				By("Fetching the Secret successfully")
 				Expect(k8sClient.Get(context.Background(), key, fetchedSecret)).Should(Succeed())
 				return true
 			}, timeout, interval).Should(BeTrue(), "The generated secret should be created")
+			defer func() {
+				By("Deleting the secret successfully")
+				Expect(k8sClient.Delete(context.Background(), fetchedSecret)).Should(Succeed())
+			}()
 
 			Expect(fetchedSecret.Data).Should(Equal(expectedMap), "Secret data should match test data")
-
-			By("Deleting the ExternalSecret successfully")
-			Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
-			By("Deleting the Secret successfully")
-			Expect(k8sClient.Delete(context.Background(), fetchedSecret)).Should(Succeed())
-			By("Deleting the SecretStore successfully")
-			Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
 		})
 
 		It("An ExternalSecret with a template fields should be set", func() {
 			store := sampleStore.DeepCopy()
+			By("Creating the SecretStore successfully")
 			Expect(k8sClient.Create(context.Background(), store)).Should(Succeed())
-
+			defer func() {
+				By("Deleting the SecretStore successfully")
+				Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
+			}()
 			expectedAnnotations := map[string]string{
 				"testKey": "testValue",
 			}
@@ -376,7 +391,10 @@ var _ = Describe("ExternalSecrets Controller", func() {
 
 			By("Creating the ExternalSecret successfully")
 			Expect(k8sClient.Create(context.Background(), toCreate)).Should(Succeed())
-			time.Sleep(time.Second * 5)
+			defer func() {
+				By("Deleting the ExternalSecret successfully")
+				Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
+			}()
 
 			fetched := &smv1alpha1.ExternalSecret{}
 			Eventually(func() bool {
@@ -392,20 +410,23 @@ var _ = Describe("ExternalSecrets Controller", func() {
 				Expect(k8sClient.Get(context.Background(), key, fetchedSecret)).Should(Succeed())
 				return true
 			}, timeout, interval).Should(BeTrue(), "The generated secret should be created")
+			defer func() {
+				By("Deleting the Secret successfully")
+				Expect(k8sClient.Delete(context.Background(), fetchedSecret)).Should(Succeed())
+			}()
 
 			Expect(fetchedSecret.Data).Should(Equal(expectedData), "Secret data should match test data")
 			Expect(fetchedSecret.Annotations).Should(Equal(expectedAnnotations), "Secret generated should have annotations from ExternalSecret template field")
-
-			By("Deleting the ExternalSecret successfully")
-			Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
-			By("Deleting the SecretStore successfully")
-			Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
 		})
 
 		It("An ExternalSecret with invalid template field should report NotReady", func() {
 			store := sampleStore.DeepCopy()
+			By("Creating the SecretStore successfully")
 			Expect(k8sClient.Create(context.Background(), store)).Should(Succeed())
-
+			defer func() {
+				By("Deleting the SecretStore successfully")
+				Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
+			}()
 			templateObject := map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"annotations": "invalid type",
@@ -452,20 +473,20 @@ var _ = Describe("ExternalSecrets Controller", func() {
 
 			By("Creating the ExternalSecret successfully")
 			Expect(k8sClient.Create(context.Background(), toCreate)).Should(Succeed())
-			time.Sleep(time.Second * 5)
+			defer func() {
+				By("Deleting the ExternalSecret successfully")
+				Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
+			}()
 
 			fetched := &smv1alpha1.ExternalSecret{}
 			Eventually(func() bool {
+				By("Fetching the ExternalSecret successfully")
 				Expect(k8sClient.Get(context.Background(), key, fetched)).Should(Succeed())
+				By("Checking the Status Condition")
 				fetchedCond := fetched.Status.GetCondition(smmeta.TypeReady)
 				return fetchedCond.Matches(smmeta.Unavailable()) &&
 					matches(fetchedCond.Message, errTemplateFailed)
 			}, timeout, interval).Should(BeTrue(), "The ExternalSecret should have a NotReady condition")
-
-			By("Deleting the ExternalSecret successfully")
-			Expect(k8sClient.Delete(context.Background(), toCreate)).Should(Succeed())
-			By("Deleting the SecretStore successfully")
-			Expect(k8sClient.Delete(context.Background(), store)).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Using `mgr.GetClient()` returns a client with a cached Informer, which leads to unreliable test. With this change can remove all calls to `time.Sleep`.