### PR TITLE
Update kind.yaml apiVersion

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,7 @@ name: e2e
 on:
   push:
     branches:
-    - master
+    - '*'
     tags:
       - 'v*.*.*'
     paths:
@@ -12,7 +12,9 @@ on:
       - 'go.sum'
       - 'Dockerfile'
   pull_request:
-    branches: master
+    branches:
+      - '*'
+    tags:
     paths:
       - 'cmd/**'
       - 'pkg/**'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'cmd/**'
       - 'pkg/**'
+      - 'e2e/**'
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'
@@ -18,6 +19,7 @@ on:
     paths:
       - 'cmd/**'
       - 'pkg/**'
+      - 'e2e/**'
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0
         with:
+          version: v0.9.0
           node_image: kindest/node:v1.19.1
           cluster_name: secret-manager
       - name: Run e2e tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,7 @@ name: e2e
 on:
   push:
     branches:
-    - '*'
+    - master
     tags:
       - 'v*.*.*'
     paths:
@@ -14,7 +14,7 @@ on:
       - 'Dockerfile'
   pull_request:
     branches:
-      - '*'
+      - master
     tags:
     paths:
       - 'cmd/**'

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,7 +7,7 @@
 ### Prerequisites
 
 * docker
-* kind
+* kind `v.0.9.0` or greater
 * ginkgo
 * kubectl
 

--- a/e2e/kind.yaml
+++ b/e2e/kind.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
 - |
   apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The `apiVersion` in `kind.yaml` causes an error:

```bash
± make start-kind
kind create cluster \
	 --name secret-manager \
	 --config kind.yaml \
	 --retain \
	 --image "kindest/node:v1.19.0"
ERROR: failed to create cluster: unknown apiVersion: kind.sigs.k8s.io/v1alpha3
make: *** [start-kind] Error 1

± kind version
kind v0.9.0 go1.15.2 darwin/amd64
```

Update it to match [kind-example.config.yaml](https://github.com/kubernetes-sigs/kind/blob/master/site/content/docs/user/kind-example-config.yaml#L4) from the [kubernetes-sigs/kind](https://github.com/kubernetes-sigs/kind) repo.