### PR TITLE
Remove base64 encoding of Secret

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: '0 10 * * *' # everyday at 10am
   push:
-    branches: master
     tags:
       - 'v*.*.*'
     paths:

--- a/pkg/controller/externalsecret/controller.go
+++ b/pkg/controller/externalsecret/controller.go
@@ -16,7 +16,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -172,12 +171,6 @@ func (r *ExternalSecretReconciler) getSecret(ctx context.Context, storeClient st
 			return nil, fmt.Errorf("name %q: %w", secretRef.RemoteRef.Name, err)
 		}
 		secretDataMap[secretRef.SecretKey] = secretData
-	}
-
-	for secretKey, secretData := range secretDataMap {
-		dstBytes := make([]byte, base64.StdEncoding.EncodedLen(len(secretData)))
-		base64.StdEncoding.Encode(dstBytes, secretData)
-		secretDataMap[secretKey] = dstBytes
 	}
 
 	return secretDataMap, nil

--- a/pkg/controller/externalsecret/controller_test.go
+++ b/pkg/controller/externalsecret/controller_test.go
@@ -16,7 +16,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -211,7 +210,7 @@ var _ = Describe("ExternalSecrets Controller", func() {
 
 			testSecretData := []byte("this-is-a-secret")
 			expectedData := map[string][]byte{
-				"key": base64Encode(testSecretData),
+				"key": testSecretData,
 			}
 			storeFactory.WithGetSecret(testSecretData, nil)
 			storeFactory.WithNew(func(context.Context, logr.Logger, client.Client, client.Reader,
@@ -307,8 +306,8 @@ var _ = Describe("ExternalSecrets Controller", func() {
 			}
 			testSecretData := []byte("value3")
 			expectedMap := map[string][]byte{
-				"key1": base64Encode(testSecretMap["key1"]),
-				"key2": base64Encode(testSecretData),
+				"key1": testSecretMap["key1"],
+				"key2": testSecretData,
 			}
 			storeFactory.WithGetSecretMap(testSecretMap, nil)
 			storeFactory.WithGetSecret(testSecretData, nil)
@@ -398,7 +397,7 @@ var _ = Describe("ExternalSecrets Controller", func() {
 
 			testSecretData := []byte("this-is-a-test-secret")
 			expectedData := map[string][]byte{
-				"key1": base64Encode(testSecretData),
+				"key1": testSecretData,
 			}
 			storeFactory.WithGetSecret(testSecretData, nil)
 			storeFactory.WithNew(func(context.Context, logr.Logger, client.Client, client.Reader,
@@ -508,12 +507,6 @@ var _ = Describe("ExternalSecrets Controller", func() {
 		})
 	})
 })
-
-func base64Encode(src []byte) []byte {
-	dst := make([]byte, base64.StdEncoding.EncodedLen(len(src)))
-	base64.StdEncoding.Encode(dst, src)
-	return dst
-}
 
 // arbitrary SecretStore to use when injecting factory
 var sampleStore = &smv1alpha1.SecretStore{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes base64 encoding. I verified that we do not need to base64 encode:

> You do not need to pre-encode it. Simply place your []byte data there

- https://github.com/munnerz

https://kubernetes.slack.com/archives/C0EG7JC6T/p1602695088211400?thread_ts=1602693575.207000&cid=C0EG7JC6T

Also see the docs for `Data`:
https://github.com/kubernetes/kubernetes/blob/6718c7654d29fafc0ee846247956839e91bce508/staging/src/k8s.io/api/core/v1/types.go#L5626-L5631

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->



**Which issue this PR fixes**

Fixes #52 

**Other notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove base64 encoding of Secret

> You do not need to pre-encode it. Simply place your []byte data there

- https://github.com/munnerz

https://kubernetes.slack.com/archives/C0EG7JC6T/p1602695088211400?thread_ts=1602693575.207000&cid=C0EG7JC6T

Also see the docs for `Data`:
https://github.com/kubernetes/kubernetes/blob/6718c7654d29fafc0ee846247956839e91bce508/staging/src/k8s.io/api/core/v1/types.go#L5626-L5631
```
