### PR TITLE
Fix wrong tokenPath in Vault store

### DIFF
--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -302,7 +302,7 @@ func (v *Vault) requestTokenWithKubernetesAuth(ctx context.Context, client Clien
 	var jwt string
 	var err error
 	if kubernetesAuth.SecretRef == nil {
-		tokenPath := "/var/run/secrets/kubernetes.io/serviceaccount"
+		tokenPath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
 		if _, err = os.Stat(tokenPath); !os.IsNotExist(err) {
 			var jwtByte []byte
 			jwtByte, err = ioutil.ReadFile(tokenPath)


### PR DESCRIPTION
* /var/run/secrets/kubernetes.io/serviceaccount/ is a directory
* /var/run/secrets/kubernetes.io/serviceaccount/token is the proper token path

**What this PR does / why we need it**:

This PR fixes a wrong path being used in Vault store. `/var/run/secrets/kubernetes.io/serviceaccount` is a directory, the token is at `/var/run/secrets/kubernetes.io/serviceaccount/token`

