### PR TITLE
Fix contributing link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 ## [Troubleshooting](./troubleshooting.md)
 
-## [Contributing](./contributing.md)
+## [Contributing](./contributing)
 
 ## FAQ
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The link to contributing is broken. This fixes it.